### PR TITLE
Rotary Encoder debounce time spin now accepts 3 decimals

### DIFF
--- a/client/buttonbox_client/ui/settings.ui
+++ b/client/buttonbox_client/ui/settings.ui
@@ -186,6 +186,9 @@
      </item>
      <item>
       <widget class="QDoubleSpinBox" name="rotaryDebounceSpin">
+       <property name="decimals">
+        <number>3</number>
+       </property>
        <property name="maximum">
         <double>10.000000000000000</double>
        </property>


### PR DESCRIPTION
Rotary Encoder debounce time spin now accepts 3 decimals